### PR TITLE
W21 75 filesystemchildren

### DIFF
--- a/Backend/filesystem/endpoints.go
+++ b/Backend/filesystem/endpoints.go
@@ -115,24 +115,24 @@ func DeleteFilesystemEntity(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// // Handler for retrieving children
-// func GetChildren(w http.ResponseWriter, r *http.Request) {
-// 	var input ValidInfoRequest
-// 	if validRequest := httpUtil.ParseParamsToSchema(w, r, []string{"GET"}, map[int]string{
-// 		400: "missing EntityID paramater",
-// 		405: "invalid method",
-// 	}, &input); validRequest {
+// Handler for retrieving children
+func GetChildren(w http.ResponseWriter, r *http.Request) {
+	var input ValidInfoRequest
+	if validRequest := httpUtil.ParseParamsToSchema(w, r, []string{"GET"}, map[int]string{
+		400: "missing EntityID paramater",
+		405: "invalid method",
+	}, &input); validRequest {
 
-// 		fileInfo, err := getEntityChildren(httpDbPool, input.EntityID)
-// 		if err != nil {
-// 			httpUtil.ThrowRequestError(w, 404, "unable to find entity with requested ID")
-// 			return
-// 		}
+		fileInfo, err := getEntityChildren(httpDbPool, input.EntityID)
+		if err != nil {
+			httpUtil.ThrowRequestError(w, 404, "unable to find entity with requested ID")
+			return
+		}
 
-// 		out, _ := json.Marshal(fileInfo)
-// 		httpUtil.SendResponse(w, string(out))
-// 	}
-// }
+		out, _ := json.Marshal(fileInfo)
+		httpUtil.SendResponse(w, string(out))
+	}
+}
 
 type ValidRenameRequest struct {
 	EntityID int    `schema:"EntityID,required"`

--- a/Backend/filesystem/service.go
+++ b/Backend/filesystem/service.go
@@ -4,6 +4,7 @@ import (
 	"DiffSync/database"
 	"context"
 	"errors"
+	"strconv"
 
 	"github.com/jackc/pgtype"
 )
@@ -97,8 +98,8 @@ func renameEntity(pool database.Pool, entityID int, newName string) error {
 	return err
 }
 
-// getFilesystemInfo returns information regarding a specific file system entity
-func getEntityChildren(pool database.Pool, docID int) ([]string, error) {
+// getFilesystemChildren returns the list of children for a file system entity
+func getEntityChildren(pool database.Pool, docID int) ([]EntityInfo, error) {
 	children := pgtype.Hstore{}
 
 	err := pool.GetConn().QueryRow(context.Background(), "SELECT children FROM filesystem WHERE entityid = $1",
@@ -107,10 +108,12 @@ func getEntityChildren(pool database.Pool, docID int) ([]string, error) {
 		return nil, errors.New("failed to read from database")
 	}
 
-	list := []string{}
+	list := []EntityInfo{}
 
 	for k := range children.Map {
-		list = append(list, k)
+		id, _ := strconv.Atoi(k)
+		info, _ := getFilesystemInfo(pool, id)
+		list = append(list, info)
 	}
 
 	return list, nil

--- a/Backend/filesystem/service.go
+++ b/Backend/filesystem/service.go
@@ -97,20 +97,21 @@ func renameEntity(pool database.Pool, entityID int, newName string) error {
 	return err
 }
 
-// // getFilesystemInfo returns information regarding a specific file system entity
-// func getEntityChildren(pool database.Pool, docID int) (EntityInfo, error) {
-// 	entity := EntityInfo{}
-// 	children := pgtype.Hstore{}
+// getFilesystemInfo returns information regarding a specific file system entity
+func getEntityChildren(pool database.Pool, docID int) ([]string, error) {
+	children := pgtype.Hstore{}
 
-// 	err := pool.GetConn().QueryRow(context.Background(), "SELECT EntityID FROM filesystem WHERE Parent = $1",
-// 		docID).Scan(&entity.EntityID, &entity.EntityName, &entity.IsDocument, &children)
-// 	if err != nil {
-// 		return EntityInfo{}, errors.New("failed to read from database")
-// 	}
+	err := pool.GetConn().QueryRow(context.Background(), "SELECT children FROM filesystem WHERE entityid = $1",
+		docID).Scan(&children)
+	if err != nil {
+		return nil, errors.New("failed to read from database")
+	}
 
-// 	for k := range children.Map {
-// 		entity.Children = append(entity.Children, k)
-// 	}
+	list := []string{}
 
-// 	return entity, nil
-// }
+	for k := range children.Map {
+		list = append(list, k)
+	}
+
+	return list, nil
+}

--- a/Backend/filesystem/service_test.go
+++ b/Backend/filesystem/service_test.go
@@ -140,3 +140,46 @@ func TestEntityRename(t *testing.T) {
 	assert.Nil(renameEntity(pool, newDir, "zoinks"))
 
 }
+
+func TestEntityChildren(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test setup
+
+	dir1, _ := createFilesystemEntityAtRoot(pool, "d1", ADMIN, false)
+	dir2, _ := createFilesystemEntityAtRoot(pool, "d2", ADMIN, false)
+	dir3, _ := createFilesystemEntityAtRoot(pool, "d3", ADMIN, false)
+	dir4, _ := createFilesystemEntityAtRoot(pool, "d4", ADMIN, false)
+	emptyDir, _ := createFilesystemEntityAtRoot(pool, "de", ADMIN, false)
+
+	for x := 1; x < 10; x++ {
+		if x%3 == 0 {
+			createFilesystemEntity(pool, dir1, "cool_doc"+string(x), ADMIN, true)
+		}
+		if x%5 == 0 {
+			createFilesystemEntity(pool, dir2, "cool_doc"+string(x), ADMIN, true)
+		}
+		if x%2 == 0 {
+			createFilesystemEntity(pool, dir3, "cool_doc"+string(x), ADMIN, true)
+		}
+		createFilesystemEntity(pool, dir4, "cool_doc"+string(x), ADMIN, true)
+	}
+
+	assert.NotNil(getEntityChildren(pool, dir1))
+	assert.NotNil(getEntityChildren(pool, dir2))
+	assert.NotNil(getEntityChildren(pool, dir3))
+	assert.NotNil(getEntityChildren(pool, dir4))
+
+	d1_kids, _ := getEntityChildren(pool, dir1)
+	d2_kids, _ := getEntityChildren(pool, dir2)
+	d3_kids, _ := getEntityChildren(pool, dir3)
+	d4_kids, _ := getEntityChildren(pool, dir4)
+	de_kids, _ := getEntityChildren(pool, emptyDir)
+
+	assert.True(len(d1_kids) == 3)
+	assert.True(len(d2_kids) == 1)
+	assert.True(len(d3_kids) == 4)
+	assert.True(len(d4_kids) == 9)
+	assert.True(len(de_kids) == 0)
+
+}

--- a/Backend/main.go
+++ b/Backend/main.go
@@ -20,6 +20,7 @@ func main() {
 	mux.HandleFunc("/filesystem/create", filesystem.CreateNewEntity)
 	mux.HandleFunc("/filesystem/delete", filesystem.DeleteFilesystemEntity)
 	mux.HandleFunc("/filesystem/rename", filesystem.RenameFilesystemEntity)
+	mux.HandleFunc("/filesystem/children", filesystem.GetChildren)
 	mux.HandleFunc("/login", auth.LoginHandler)
 	mux.HandleFunc("/logout", auth.LogoutHandler)
 	mux.Handle("/", http.FileServer(http.Dir("./html")))


### PR DESCRIPTION
This PR implements a function which pulls all entity children as a list of IDs. This function uses the children row in the db, so it is safe to remove the parent row in the future without changes to this property. Unit tests are included and there is little else to report for this :)