### PR TITLE
[EASY][BUG] Filename rename doesnt actually change the name

### DIFF
--- a/Frontend/src/packages/dashboard/api/index.ts
+++ b/Frontend/src/packages/dashboard/api/index.ts
@@ -39,7 +39,7 @@ export async function updateContents(id: number) {
 }
 
 
-export const newFile = async (name: string): Promise<Response> => {
+export const newFile = async (name: string): Promise<string> => {
 
   // This isn't attached to the parent folder yet,
   // TODO: patch once auth is finished
@@ -56,8 +56,8 @@ export const newFile = async (name: string): Promise<Response> => {
     const message = `An error has occured: ${create_resp.status}`;
     throw new Error(message);
   }
-
-  return create_resp;
+  const response = await create_resp.json();
+  return response.Response.NewID;
 }
 
 export const newFolder = async (name: string): Promise<string> => {


### PR DESCRIPTION
## **Why this change was required?**

- after creating a new page and trying to rename the page for the first time, the rename doesn't work (after entering the rename, it goes back to the initial name)
- this was because the page didn't have a valid ID intially.

## **Changes**
- Changed api for newFile to return the ID instead of JSON