### PR TITLE
[CMS-254] Backend - Improve error handling

### DIFF
--- a/Backend/endpoints/auth_endpoints.go
+++ b/Backend/endpoints/auth_endpoints.go
@@ -36,7 +36,7 @@ type User struct {
 */
 func LoginHandler(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var user User
-	if !ParseParamsToSchema(r, "POST", &user) {
+	if status := ParseParamsToSchema(r, "POST", &user); status != http.StatusOK {
 		http.Redirect(w, r, environment.GetFrontendURI()+"/login", http.StatusMovedPermanently)
 		return http.StatusMovedPermanently, nil, nil
 	}

--- a/Backend/endpoints/filesystem_endpoints.go
+++ b/Backend/endpoints/filesystem_endpoints.go
@@ -50,7 +50,7 @@ func GetEntityInfo(w http.ResponseWriter, r *http.Request, df DependencyFactory)
 			Children:   childrenArr,
 		}, nil
 	} else {
-		return http.StatusNotFound, nil, nil
+		return http.StatusNotFound, nil, err
 	}
 }
 
@@ -78,7 +78,7 @@ func CreateNewEntity(w http.ResponseWriter, r *http.Request, df DependencyFactor
 	}
 
 	if e, err := repository.CreateEntry(entityToCreate); err != nil {
-		return http.StatusNotAcceptable, nil, nil
+		return http.StatusNotAcceptable, nil, err
 	} else {
 		return http.StatusOK, struct {
 			NewID int
@@ -98,8 +98,8 @@ func DeleteFilesystemEntity(w http.ResponseWriter, r *http.Request, df Dependenc
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
-	if repository.DeleteEntryWithID(input.EntityID) != nil {
-		return http.StatusNotAcceptable, nil, nil
+	if err := repository.DeleteEntryWithID(input.EntityID); err != nil {
+		return http.StatusNotAcceptable, nil, err
 	} else {
 		return http.StatusOK, nil, nil
 	}
@@ -115,7 +115,7 @@ func GetChildren(w http.ResponseWriter, r *http.Request, df DependencyFactory) (
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
 	if fileInfo, err := repository.GetEntryWithID(input.EntityID); err != nil {
-		return http.StatusNotFound, nil, nil
+		return http.StatusNotFound, nil, err
 	} else {
 		return http.StatusOK, struct {
 			Children []int
@@ -138,7 +138,7 @@ func GetIDWithPath(w http.ResponseWriter, r *http.Request, df DependencyFactory)
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
 	if entityID, err := repository.GetIDWithPath(input.Path); err != nil {
-		return http.StatusNotFound, nil, nil
+		return http.StatusNotFound, nil, err
 	} else {
 		return http.StatusOK, entityID, nil
 	}
@@ -158,8 +158,8 @@ func RenameFilesystemEntity(w http.ResponseWriter, r *http.Request, df Dependenc
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
-	if repository.RenameEntity(input.EntityID, input.NewName) != nil {
-		return http.StatusNotAcceptable, nil, nil
+	if err := repository.RenameEntity(input.EntityID, input.NewName); err != nil {
+		return http.StatusNotAcceptable, nil, err
 	} else {
 		return http.StatusOK, nil, nil
 	}

--- a/Backend/endpoints/filesystem_endpoints.go
+++ b/Backend/endpoints/filesystem_endpoints.go
@@ -50,7 +50,7 @@ func GetEntityInfo(w http.ResponseWriter, r *http.Request, df DependencyFactory)
 			Children:   childrenArr,
 		}, nil
 	} else {
-		return http.StatusNotFound, nil, err
+		return http.StatusNotFound, nil, nil
 	}
 }
 
@@ -115,7 +115,7 @@ func GetChildren(w http.ResponseWriter, r *http.Request, df DependencyFactory) (
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
 	if fileInfo, err := repository.GetEntryWithID(input.EntityID); err != nil {
-		return http.StatusNotFound, nil, err
+		return http.StatusNotFound, nil, nil
 	} else {
 		return http.StatusOK, struct {
 			Children []int
@@ -138,7 +138,7 @@ func GetIDWithPath(w http.ResponseWriter, r *http.Request, df DependencyFactory)
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
 	if entityID, err := repository.GetIDWithPath(input.Path); err != nil {
-		return http.StatusNotFound, nil, err
+		return http.StatusNotFound, nil, nil
 	} else {
 		return http.StatusOK, entityID, nil
 	}
@@ -159,7 +159,7 @@ func RenameFilesystemEntity(w http.ResponseWriter, r *http.Request, df Dependenc
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
 	repository := df.GetDependency(fs).(repositories.IFilesystemRepository)
 	if err := repository.RenameEntity(input.EntityID, input.NewName); err != nil {
-		return http.StatusNotAcceptable, nil, err
+		return http.StatusNotAcceptable, nil, nil
 	} else {
 		return http.StatusOK, nil, nil
 	}

--- a/Backend/endpoints/filesystem_endpoints.go
+++ b/Backend/endpoints/filesystem_endpoints.go
@@ -22,8 +22,8 @@ type ValidInfoRequest struct {
 // Defines endpoints consumable via the API
 func GetEntityInfo(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var input ValidInfoRequest
-	if !ParseParamsToSchema(r, "GET", &input) {
-		return http.StatusBadRequest, nil, nil
+	if status := ParseParamsToSchema(r, "GET", &input); status != http.StatusOK {
+		return status, nil, nil
 	}
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
@@ -64,8 +64,8 @@ type ValidEntityCreationRequest struct {
 
 func CreateNewEntity(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var input ValidEntityCreationRequest
-	if !ParseParamsToSchema(r, "POST", &input) {
-		return http.StatusBadRequest, nil, nil
+	if status := ParseParamsToSchema(r, "POST", &input); status != http.StatusOK {
+		return status, nil, nil
 	}
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
@@ -92,8 +92,8 @@ func CreateNewEntity(w http.ResponseWriter, r *http.Request, df DependencyFactor
 // Handler for deleting filesystem entities
 func DeleteFilesystemEntity(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var input ValidInfoRequest
-	if !ParseParamsToSchema(r, "POST", &input) {
-		return http.StatusBadRequest, nil, nil
+	if status := ParseParamsToSchema(r, "POST", &input); status != http.StatusOK {
+		return status, nil, nil
 	}
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
@@ -108,8 +108,8 @@ func DeleteFilesystemEntity(w http.ResponseWriter, r *http.Request, df Dependenc
 // Handler for retrieving children
 func GetChildren(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var input ValidInfoRequest
-	if !ParseParamsToSchema(r, "GET", &input) {
-		return http.StatusBadRequest, nil, nil
+	if status := ParseParamsToSchema(r, "GET", &input); status != http.StatusOK {
+		return status, nil, nil
 	}
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
@@ -131,8 +131,8 @@ type ValidPathRequest struct {
 
 func GetIDWithPath(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var input ValidPathRequest
-	if !ParseParamsToSchema(r, "GET", &input) {
-		return http.StatusBadRequest, nil, nil
+	if status := ParseParamsToSchema(r, "GET", &input); status != http.StatusOK {
+		return status, nil, nil
 	}
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))
@@ -152,8 +152,8 @@ type ValidRenameRequest struct {
 // Handler for renaming filesystem entities
 func RenameFilesystemEntity(w http.ResponseWriter, r *http.Request, df DependencyFactory) (int, interface{}, error) {
 	var input ValidRenameRequest
-	if !ParseParamsToSchema(r, "POST", &input) {
-		return http.StatusBadRequest, nil, nil
+	if status := ParseParamsToSchema(r, "POST", &input); status != http.StatusOK {
+		return status, nil, nil
 	}
 
 	fs := reflect.TypeOf((*repositories.IFilesystemRepository)(nil))

--- a/Backend/endpoints/main.go
+++ b/Backend/endpoints/main.go
@@ -7,7 +7,7 @@ import (
 	"cms.csesoc.unsw.edu.au/internal/session"
 )
 
-// Basic organisation of a response we will receieve from the API
+// Basic organisation of a response we will receive from the API
 type Response struct {
 	Status   int
 	Message  string
@@ -18,7 +18,7 @@ type Response struct {
 // a bit easier and less messy
 type handler func(http.ResponseWriter, *http.Request, DependencyFactory) (int, interface{}, error)
 
-// authenticated handler is basically a regular http handler the only difference is that
+// Authenticated handler is basically a regular http handler the only difference is that
 // they can only be accessed by an authenticated client
 type authenticatedHandler func(http.ResponseWriter, *http.Request, DependencyFactory) (int, interface{}, error)
 
@@ -65,7 +65,7 @@ func (fn handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// authentiacated handler impl
+// Authenticated handler impl
 func (fn authenticatedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// check authentication
 	if ok, err := session.IsAuthenticated(w, r); !ok || err != nil {

--- a/Backend/endpoints/util.go
+++ b/Backend/endpoints/util.go
@@ -32,13 +32,13 @@ func SendResponse(w http.ResponseWriter, marshaledJson string) {
 
 // ParseParamsToSchema expects the target to be a pointer
 func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interface{}) int {
+	if acceptingMethod != r.Method {
+		return http.StatusMethodNotAllowed
+	}
+
 	err := r.ParseForm()
 	if err != nil {
 		return http.StatusBadRequest
-	}
-
-	if acceptingMethod != r.Method {
-		return http.StatusMethodNotAllowed
 	}
 
 	decoder := schema.NewDecoder()

--- a/Backend/endpoints/util.go
+++ b/Backend/endpoints/util.go
@@ -31,14 +31,14 @@ func SendResponse(w http.ResponseWriter, marshaledJson string) {
 }
 
 // ParseParamsToSchema expects the target to be a pointer
-func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interface{}) bool {
+func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interface{}) int {
 	err := r.ParseForm()
 	if err != nil {
-		return false
+		return http.StatusBadRequest
 	}
 
 	if acceptingMethod != r.Method {
-		return false
+		return http.StatusMethodNotAllowed
 	}
 
 	decoder := schema.NewDecoder()
@@ -48,8 +48,8 @@ func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interfa
 		err = decoder.Decode(target, r.PostForm)
 	}
 	if err != nil {
-		return false
+		return http.StatusBadRequest
 	}
 
-	return true
+	return http.StatusOK
 }


### PR DESCRIPTION
- Make the function `ParseParamsToSchema` return the http status code instead of a bool
- ~~Make `Handler` functions return the error~~
- ~~Adjust HTTP message to be the error if one was raised~~

Last two points are ignored since the server will only return a response if there was no error