### PR TITLE
[CMS-283] Fixing broken development dockerfiles

### DIFF
--- a/Backend/Dockerfile.development
+++ b/Backend/Dockerfile.development
@@ -1,0 +1,29 @@
+FROM golang:1.17-alpine as build-env
+
+# make current working directory /app
+WORKDIR /go/src/cms.csesoc.unsw.edu.au
+
+# copy go.mod and go.sum
+COPY go.mod go.sum ./
+
+COPY . .
+
+
+# downloding dependencies
+RUN go mod download
+RUN apk add --update npm
+RUN go get github.com/githubnemo/CompileDaemon
+
+WORKDIR editor/html
+RUN npm install
+WORKDIR ../../
+
+EXPOSE 8080
+
+# export environment variable for gopath
+ENV GOPATH /go
+
+# might start the app
+#CMD ["go", "run", "main.go"]
+
+ENTRYPOINT CompileDaemon --build="go build main.go" --command="./main"

--- a/Config/.env.dev.example
+++ b/Config/.env.dev.example
@@ -4,3 +4,4 @@ PG_USER=postgres
 PG_PASSWORD=postgres
 PG_DB=test_db
 PG_PORT=5432
+COMPOSE_HTTP_TIMEOUT=200

--- a/Frontend/Dockerfile.development
+++ b/Frontend/Dockerfile.development
@@ -1,0 +1,21 @@
+# pulling official base image
+FROM node:13.12.0-alpine
+
+# Setting working directory
+WORKDIR /app
+
+# Cache and Install dependnecies
+COPY package.json package-lock.json ./
+RUN npm install 
+
+COPY . .
+
+# exposing ports
+EXPOSE 3000
+
+# setting environment variables
+ARG BACKEND_URI
+ENV REACT_APP_BACKEND_URI $BACKEND_URI
+
+# npm start
+CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,16 @@ pg:
 	--env-file=./Config/.env.dev \
 	up --build
 
+cms-only:
+	docker-compose \
+	--env-file=./Config/.env.dev \
+	up frontend backend db
+
+next-only:
+	docker-compose \
+	--env-file=./Config/.env.dev \
+	up next backend db
+
 clean:
 	docker-compose \
 	--env-file=./Config/.env.dev \

--- a/Next/Dockerfile.development
+++ b/Next/Dockerfile.development
@@ -1,0 +1,21 @@
+# pulling official base image
+FROM node:13.12.0-alpine
+
+# Setting working directory
+WORKDIR /next
+
+# Cache and Install dependnecies
+COPY package.json .
+RUN npm install 
+
+COPY . .
+
+# exposing ports
+EXPOSE 3001
+
+# setting environment variables
+ARG BACKEND_URI
+ENV REACT_APP_BACKEND_URI $BACKEND_URI
+
+# npm start
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       - POSTGRES_PASSWORD=${PG_PASSWORD}
       - POSTGRES_DB=${PG_DB}
       - POSTGRES_PORT=${PG_PORT}
-
   db:
     container_name: pg_container
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: Next
     build:
       context: ./Next
+      dockerfile: ./Dockerfile.development
       args:
         BACKEND_URI: ${BACKEND_URI}
     volumes:
@@ -17,6 +18,7 @@ services:
     container_name: Frontend
     build: 
       context: ./Frontend
+      dockerfile: ./Dockerfile.development
       args: 
         BACKEND_URI: ${BACKEND_URI}
     volumes:
@@ -28,7 +30,9 @@ services:
       - 3000:3000
   backend:
     container_name: go_backend
-    build: ./Backend
+    build: 
+      context: ./Backend
+      dockerfile: ./Dockerfile.development
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
### Why was it necessary?
Dockerfiles were changed to production dockerfiles, breaking development docker-compose

### Changes
- added dockerfile.development
- updated docker-compose to use development dockerfiles
- updated makefile to allow for `cms-only` and `next-only` builds