### PR TITLE
feat(backend): move postgres host to env var

### DIFF
--- a/Backend/database/contexts/live_context.go
+++ b/Backend/database/contexts/live_context.go
@@ -27,7 +27,7 @@ type liveContext struct {
 // NewPool returns a new pool from a given configuration
 func newLiveContext() (*liveContext, error) {
 	conn, err := pgxpool.Connect(context.Background(),
-		fmt.Sprintf("postgres://%s:%s@%s/%s", USER, PASSWORD, HOST_AND_PORT, DATABASE))
+		fmt.Sprintf("postgres://%s:%s@%s/%s", USER, PASSWORD, HOST, DATABASE))
 	if err != nil {
 		return nil, errors.New("unable to connect to the database")
 	}

--- a/Backend/database/contexts/main.go
+++ b/Backend/database/contexts/main.go
@@ -9,10 +9,9 @@ import (
 
 // Constants regarding database connections
 var USER = environment.GetDBUser()
+var HOST = environment.GetDBHost()
 var PASSWORD = environment.GetDBPassword()
 var DATABASE = environment.GetDB()
-
-const HOST_AND_PORT = "db:5432"
 
 const TEST_USER = "postgres"
 const TEST_PASSWORD = "test"

--- a/Backend/environment/config.go
+++ b/Backend/environment/config.go
@@ -8,11 +8,12 @@ func GetFrontendURI() string {
 	return os.Getenv("FRONTEND_URI")
 }
 
-// having a hard time dealing with environment variable injection
-// into the docker container
-// so hard coding it
 func GetDBUser() string {
 	return os.Getenv("POSTGRES_USER")
+}
+
+func GetDBHost() string {
+	return os.Getenv("POSTGRES_HOST")
 }
 
 func GetDBPassword() string {


### PR DESCRIPTION
This PR allows the postgres address to be set via the `POSTGRES_HOST` environment variable.