### PR TITLE
[CMS-273] Resize ContentBlockWrapper

### DIFF
--- a/Frontend/src/cse-ui-kit/contentblock/contentblock-Styled.tsx
+++ b/Frontend/src/cse-ui-kit/contentblock/contentblock-Styled.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const StyledContent = styled.div`
   width: 100%;
-  max-width: 400px;
+  max-width: 600px;
   background: #ffffff;
   color: #000000;
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.25);

--- a/Frontend/src/packages/editor/components/EditorBlock.tsx
+++ b/Frontend/src/packages/editor/components/EditorBlock.tsx
@@ -93,7 +93,7 @@ const EditorBlock: FC<EditorBlockProps> = ({
         <Editable
           renderLeaf={renderLeaf}
           onClick={() => onEditorClick()}
-          style={{ width: "200%", height: "200%" }}
+          style={{ width: "100%", height: "100%" }}
         />
       </ContentBlock>
     </Slate>

--- a/Frontend/src/packages/editor/components/EditorBlock.tsx
+++ b/Frontend/src/packages/editor/components/EditorBlock.tsx
@@ -18,7 +18,7 @@ const ToolbarContainer = styled.div`
   display: flex;
   flex-direction: row;
   width: 100%;
-  max-width: 440px;
+  max-width: 660px;
   margin: 5px;
 `;
 
@@ -93,7 +93,7 @@ const EditorBlock: FC<EditorBlockProps> = ({
         <Editable
           renderLeaf={renderLeaf}
           onClick={() => onEditorClick()}
-          style={{ width: "100%", height: "100%" }}
+          style={{ width: "200%", height: "200%" }}
         />
       </ContentBlock>
     </Slate>


### PR DESCRIPTION
## **Why this change was required?**

- To fill the screen and make text entry more ergonomic with longer lines

## **Changes**

- Changed width of block
- Ensured style buttons (bold, underline, etc) stayed in the same relative position to the top left of the resized block

## **Screenshots**
Note editor is currently unable to be previewed and so UI screenshot may not be very meaningful
![image](https://user-images.githubusercontent.com/49307682/175330881-2fa8b12f-a5c0-494d-bf45-d9dce56f1fdb.png)

