### PR TITLE
[CMS-236] Add image upload endpoint

### DIFF
--- a/Backend/endpoints/filesystem_endpoints.go
+++ b/Backend/endpoints/filesystem_endpoints.go
@@ -216,6 +216,11 @@ func UploadImage(w http.ResponseWriter, r *http.Request, df DependencyFactory, l
 		return status, nil, nil
 	}
 
+	// Parse multipart file, with max size of 10 MB
+	var maxUploadSize int64 = 10 << 20
+	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
+		return http.StatusBadRequest, nil, err
+	}
 	// Extract image and check for error
 	file, _, err := r.FormFile("Image")
 	if err != nil {

--- a/Backend/endpoints/filesystem_endpoints.go
+++ b/Backend/endpoints/filesystem_endpoints.go
@@ -36,7 +36,7 @@ func GetEntityInfo(w http.ResponseWriter, r *http.Request, df DependencyFactory,
 	log.Write([]byte("Acquired repository."))
 
 	if entity, err := repository.GetEntryWithID(input.EntityID); err == nil {
-		log.Write([]byte(fmt.Sprintf("Retreived entity: %v", entity)))
+		log.Write([]byte(fmt.Sprintf("Retreived entity: %v.", entity)))
 		// Return a final structure with the children array mapped over as well
 		return http.StatusOK, EntityInfo{
 			EntityID:   entity.EntityID,
@@ -120,7 +120,7 @@ func DeleteFilesystemEntity(w http.ResponseWriter, r *http.Request, df Dependenc
 		log.Write([]byte("Failed request!"))
 		return http.StatusNotAcceptable, nil, err
 	} else {
-		log.Write([]byte(fmt.Sprintf("Deleted entity wity ID: %d", input.EntityID)))
+		log.Write([]byte(fmt.Sprintf("Deleted entity wity ID: %d.", input.EntityID)))
 		return http.StatusOK, nil, nil
 	}
 }
@@ -140,7 +140,7 @@ func GetChildren(w http.ResponseWriter, r *http.Request, df DependencyFactory, l
 		log.Write([]byte("Failed request!"))
 		return http.StatusNotFound, nil, nil
 	} else {
-		log.Write([]byte(fmt.Sprintf("Fetched children for %d, got %v", input.EntityID, fileInfo.ChildrenIDs)))
+		log.Write([]byte(fmt.Sprintf("Fetched children for %d, got %v.", input.EntityID, fileInfo.ChildrenIDs)))
 		return http.StatusOK, struct {
 			Children []int
 		}{
@@ -191,7 +191,7 @@ func RenameFilesystemEntity(w http.ResponseWriter, r *http.Request, df Dependenc
 		log.Write([]byte("Failed request!"))
 		return http.StatusNotAcceptable, nil, nil
 	} else {
-		log.Write([]byte(fmt.Sprintf("Renamed %d's name to %s", input.EntityID, input.NewName)))
+		log.Write([]byte(fmt.Sprintf("Renamed %d's name to %s.", input.EntityID, input.NewName)))
 		return http.StatusOK, nil, nil
 	}
 }
@@ -252,12 +252,12 @@ func UploadImage(w http.ResponseWriter, r *http.Request, df DependencyFactory, l
 	log.Write([]byte(fmt.Sprintf("Created new entity %v.", entityToCreate)))
 	dockerFile, err := dockerRepository.GetFromVolume(strconv.Itoa(e.EntityID))
 	if err != nil {
-		log.Write([]byte("Unable to get docker file"))
+		log.Write([]byte("Unable to get docker file."))
 		return http.StatusInternalServerError, nil, err
 	}
 
 	if _, err := io.Copy(dockerFile, uploadedFile); err != nil {
-		log.Write([]byte("Error copying uploaded image to local file"))
+		log.Write([]byte("Error copying uploaded image to local file."))
 		return http.StatusInternalServerError, nil, err
 	}
 

--- a/Backend/endpoints/filesystem_endpoints.go
+++ b/Backend/endpoints/filesystem_endpoints.go
@@ -213,15 +213,11 @@ type ValidImageUploadRequest struct {
 
 func UploadImage(w http.ResponseWriter, r *http.Request, df DependencyFactory, log *logger.Log) (int, interface{}, error) {
 	var input ValidImageUploadRequest
-	if status := ParseParamsToSchema(r, "POST", &input); status != http.StatusOK {
+	if status := ParseMultiPartFormToSchema(r, "POST", &input); status != http.StatusOK {
 		return status, nil, nil
 	}
 
 	// Parse multipart file, with max size of 10 MB
-	var maxUploadSize int64 = 10 << 20
-	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
-		return http.StatusBadRequest, nil, err
-	}
 	// Extract image and check for error
 	uploadedFile, _, err := r.FormFile("Image")
 	if err != nil {

--- a/Backend/endpoints/registration.go
+++ b/Backend/endpoints/registration.go
@@ -5,11 +5,11 @@ import "net/http"
 // Registers the correct decorators for the endpoints too
 func RegisterFilesystemEndpoints(mux *http.ServeMux) {
 	mux.Handle("/api/filesystem/info", handler(GetEntityInfo))
-	mux.Handle("/api/filesystem/create", handler(CreateNewEntity))        //auth
-	mux.Handle("/api/filesystem/delete", handler(DeleteFilesystemEntity)) //auth
-	mux.Handle("/api/filesystem/rename", handler(RenameFilesystemEntity)) //auth
+	mux.Handle("/api/filesystem/create", handler(CreateNewEntity))        // auth
+	mux.Handle("/api/filesystem/delete", handler(DeleteFilesystemEntity)) // auth
+	mux.Handle("/api/filesystem/rename", handler(RenameFilesystemEntity)) // auth
 	mux.Handle("/api/filesystem/children", handler(GetChildren))
-	mux.Handle("/api/filesystem/upload-image", handler(UploadImage))
+	mux.Handle("/api/filesystem/upload-image", handler(UploadImage)) // auth
 }
 
 // Registers the authentication based endpoints

--- a/Backend/endpoints/registration.go
+++ b/Backend/endpoints/registration.go
@@ -9,6 +9,7 @@ func RegisterFilesystemEndpoints(mux *http.ServeMux) {
 	mux.Handle("/api/filesystem/delete", handler(DeleteFilesystemEntity)) //auth
 	mux.Handle("/api/filesystem/rename", handler(RenameFilesystemEntity)) //auth
 	mux.Handle("/api/filesystem/children", handler(GetChildren))
+	mux.Handle("/api/filesystem/upload-image", handler(UploadImage))
 }
 
 // Registers the authentication based endpoints

--- a/Backend/endpoints/tests/filesystem_test.go
+++ b/Backend/endpoints/tests/filesystem_test.go
@@ -1,8 +1,13 @@
 package tests
 
 import (
+	"bytes"
+	"encoding/base64"
+	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -168,4 +173,74 @@ func TestValidGetChildren(t *testing.T) {
 	}{
 		Children: []int{2},
 	})
+}
+
+func TestValidUploadImage(t *testing.T) {
+	controller := gomock.NewController(t)
+	assert := assert.New(t)
+	defer controller.Finish()
+
+	// ==== test setup =====
+	entityToCreate := repositories.FilesystemEntry{
+		LogicalName:  "a.png",
+		ParentFileID: 1,
+		IsDocument:   false,
+		OwnerUserId:  1,
+	}
+
+	mockFileRepo := repMocks.NewMockIFilesystemRepository(controller)
+	mockFileRepo.EXPECT().CreateEntry(entityToCreate).Return(repositories.FilesystemEntry{
+		EntityID:     2,
+		LogicalName:  "a.png",
+		IsDocument:   false,
+		ChildrenIDs:  []int{},
+		ParentFileID: 1,
+	}, nil).Times(1)
+
+	tempFile, err := ioutil.TempFile("", "")
+	assert.Nil(err)
+	defer os.Remove(tempFile.Name())
+
+	mockDockerFileSystemRepo := repMocks.NewMockIDockerUnpublishedFilesystemRepository(controller)
+	mockDockerFileSystemRepo.EXPECT().AddToVolume("2").Return(nil).Times(1)
+	mockDockerFileSystemRepo.EXPECT().GetFromVolume("2").Return(tempFile, nil).Times(1)
+
+	mockDepFactory := mocks.NewMockDependencyFactory(controller)
+	mockDepFactory.EXPECT().GetDependency(reflect.TypeOf((*repositories.IFilesystemRepository)(nil))).Return(mockFileRepo)
+	mockDepFactory.EXPECT().GetDependency(reflect.TypeOf((*repositories.IDockerUnpublishedFilesystemRepository)(nil))).Return(mockDockerFileSystemRepo)
+
+	// Create request
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+
+	// Add image
+	part, err := writer.CreateFormFile("Image", "a.png")
+	assert.Nil(err)
+	base64Png := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+	pngBytes, err := base64.StdEncoding.DecodeString(base64Png)
+	assert.Nil(err)
+	part.Write(pngBytes)
+
+	// Add params
+	writer.WriteField("LogicalName", "a.png")
+	writer.WriteField("Parent", "1")
+	writer.WriteField("OwnerGroup", "1")
+	writer.Close()
+	req, err := http.NewRequest("POST", "/filesystem/image-upload", body)
+	assert.Nil(err)
+
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+
+	// ==== test execution =====
+	status, result, err := endpoints.UploadImage(nil, req, mockDepFactory, logger.OpenLog("new log"))
+	assert.Nil(err)
+	assert.Equal(http.StatusOK, status)
+	assert.Equal(result, struct {
+		NewID int
+	}{
+		NewID: 2,
+	}, nil)
+	content, err := os.ReadFile(tempFile.Name())
+	assert.Nil(err)
+	assert.Equal(pngBytes, content)
 }

--- a/Backend/endpoints/tests/filesystem_test.go
+++ b/Backend/endpoints/tests/filesystem_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEntityInfo(t *testing.T) {
+func TestValidEntityInfo(t *testing.T) {
 	controller := gomock.NewController(t)
 	assert := assert.New(t)
 	defer controller.Finish()
@@ -53,7 +53,7 @@ func TestEntityInfo(t *testing.T) {
 	})
 }
 
-func TestCreateNewEntity(t *testing.T) {
+func TestValidCreateNewEntity(t *testing.T) {
 	controller := gomock.NewController(t)
 	assert := assert.New(t)
 	defer controller.Finish()
@@ -107,7 +107,7 @@ func TestCreateNewEntity(t *testing.T) {
 	}, nil)
 }
 
-func TestDeleteFilesystemEntity(t *testing.T) {
+func TestValidDeleteFilesystemEntity(t *testing.T) {
 	controller := gomock.NewController(t)
 	assert := assert.New(t)
 	defer controller.Finish()
@@ -137,7 +137,7 @@ func TestDeleteFilesystemEntity(t *testing.T) {
 	assert.Equal(result, nil, nil)
 }
 
-func TestGetChildren(t *testing.T) {
+func TestValidGetChildren(t *testing.T) {
 	controller := gomock.NewController(t)
 	assert := assert.New(t)
 	defer controller.Finish()

--- a/Backend/endpoints/util.go
+++ b/Backend/endpoints/util.go
@@ -30,7 +30,7 @@ func SendResponse(w http.ResponseWriter, marshaledJson string) {
 		}`, marshaledJson)))
 }
 
-// ParseParamsToSchema expects the target to be a pointer, and logs errors
+// ParseParamsToSchema expects the target to be a pointer
 func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interface{}) int {
 	if acceptingMethod != r.Method {
 		return http.StatusMethodNotAllowed

--- a/Backend/endpoints/util.go
+++ b/Backend/endpoints/util.go
@@ -53,3 +53,27 @@ func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interfa
 
 	return http.StatusOK
 }
+
+func ParseMultiPartFormToSchema(r *http.Request, acceptingMethod string, target interface{}) int {
+	if acceptingMethod != r.Method {
+		return http.StatusMethodNotAllowed
+	}
+
+	var maxUploadSize int64 = 10 << 20
+	err := r.ParseMultipartForm(maxUploadSize)
+	if err != nil {
+		fmt.Print(err.Error())
+		return http.StatusBadRequest
+	}
+
+	decoder := schema.NewDecoder()
+	if r.Method != "POST" {
+		err = decoder.Decode(target, r.Form)
+	} else {
+		err = decoder.Decode(target, r.PostForm)
+	}
+	if err != nil {
+		return http.StatusBadRequest
+	}
+	return http.StatusOK
+}

--- a/Backend/endpoints/util.go
+++ b/Backend/endpoints/util.go
@@ -30,7 +30,7 @@ func SendResponse(w http.ResponseWriter, marshaledJson string) {
 		}`, marshaledJson)))
 }
 
-// ParseParamsToSchema expects the target to be a pointer
+// ParseParamsToSchema expects the target to be a pointer, and logs errors
 func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interface{}) int {
 	if acceptingMethod != r.Method {
 		return http.StatusMethodNotAllowed
@@ -38,6 +38,11 @@ func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interfa
 
 	err := r.ParseForm()
 	if err != nil {
+		return http.StatusBadRequest
+	}
+
+	// Parse multipart file, with max size of 10 MB
+	if err = r.ParseMultipartForm(10 << 20); err != nil {
 		return http.StatusBadRequest
 	}
 

--- a/Backend/endpoints/util.go
+++ b/Backend/endpoints/util.go
@@ -41,11 +41,6 @@ func ParseParamsToSchema(r *http.Request, acceptingMethod string, target interfa
 		return http.StatusBadRequest
 	}
 
-	// Parse multipart file, with max size of 10 MB
-	if err = r.ParseMultipartForm(10 << 20); err != nil {
-		return http.StatusBadRequest
-	}
-
 	decoder := schema.NewDecoder()
 	if r.Method != "POST" {
 		err = decoder.Decode(target, r.Form)


### PR DESCRIPTION
A PR to handle the uploading of images, though have some questions:

- Should we make a new private function to creation and adding of entities to the fs, so that `CreateNewEntity` and `UploadImage` can call it, reducing additional code
- Should we also add logging to `ParseParamsToSchema`?