### PR TITLE
Fix edge case in traversal and add more test cases for invalid inputs

### DIFF
--- a/Backend/editor/models/tests/models_test.go
+++ b/Backend/editor/models/tests/models_test.go
@@ -73,8 +73,7 @@ func TestInvalidFieldName(t *testing.T) {
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
-	result, err := models.Traverse(testObj, subpaths)
-	_ = result // Stop go from complaining about unused variable
+	_, err = models.Traverse(testObj, subpaths)
 	assert.NotNil(t, err)
 }
 
@@ -101,8 +100,7 @@ func TestNonIntegerArrayIndex(t *testing.T) {
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
-	result, err := models.Traverse(testObj, subpaths)
-	_ = result // Stop go from complaining about unused variable
+	result, err = models.Traverse(testObj, subpaths)
 	assert.NotNil(t, err)
 }
 
@@ -113,8 +111,7 @@ func TestOutOfBoundsArrayIndex(t *testing.T) {
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
-	result, err := models.Traverse(testObj, subpaths)
-	_ = result // Stop go from complaining about unused variable
+	_, err = models.Traverse(testObj, subpaths)
 	assert.NotNil(t, err)
 }
 

--- a/Backend/editor/models/tests/models_test.go
+++ b/Backend/editor/models/tests/models_test.go
@@ -46,7 +46,7 @@ func setupDocument() models.Document {
 	return models.Document{
 		DocumentName: "morbed up",
 		DocumentId:   "M0R8",
-		Content:      []models.Component{image, paragraph, arrayData, nil},
+		Content:      []models.Component{image, paragraph, arrayData},
 	}
 }
 
@@ -63,7 +63,7 @@ func TestValidSliceField(t *testing.T) {
 	}
 	assert := assert.New(t)
 	assert.Equal("slice", result.Kind().String())
-	assert.Equal(4, result.Len())
+	assert.Equal(3, result.Len())
 }
 
 func TestInvalidFieldName(t *testing.T) {

--- a/Backend/editor/models/traversal.go
+++ b/Backend/editor/models/traversal.go
@@ -23,23 +23,20 @@ func Traverse(d Document, subpaths []string) (reflect.Value, error) {
 				// that the next iteration of the for loop will have a struct since
 				// .NumField() must be available. Thus we must lookahead for indices
 				// to enforce this.
-
 				curr = field
-
 				switch fieldType := field.Kind(); fieldType {
 				case reflect.Array, reflect.Slice:
 					// If we are not at the end of the paths, then grab the index
-					// TODO: Add an error check here to see its actually an int
 					if i < length-1 {
 						i++
-						index, _ := strconv.ParseInt(subpaths[i], 10, 32)
-						if int(index) >= field.Len() || int(index) < 0 {
-							return reflect.Value{}, errors.New("Invalid target index")
+						index, err := strconv.Atoi(subpaths[i])
+						if err != nil || index >= field.Len() || index < 0 {
+							return reflect.Value{}, errors.New("invalid target index")
 						}
 						if fieldType == reflect.Slice {
-							curr = field.Index(int(index))
+							curr = field.Index(index)
 						} else {
-							curr = field.Elem().Index(int(index))
+							curr = field.Elem().Index(index)
 						}
 					}
 				}
@@ -54,7 +51,7 @@ func Traverse(d Document, subpaths []string) (reflect.Value, error) {
 		}
 		// Path content should always be found
 		if !found {
-			return reflect.Value{}, errors.New("Invalid path, couldn't find subpath " + subpath)
+			return reflect.Value{}, errors.New("invalid path, couldn't find subpath " + subpath)
 		}
 		found = false
 	}


### PR DESCRIPTION
- Change to use `strconv.Atoi` instead of `strconv.ParseInt`
- Add bonus test cases for invalid case
- Return error if the ascii to integer fails (if there was an error, index would be 0) resulting in invalid field)

Also wondering if there is a way to do deep equality checks - this would make the traversal testing less rigid, i.e. we check that the struct returned from traversal has deep equality with struct in `setupDocument`