### PR TITLE
OT Server - Adding Operation History Record

### DIFF
--- a/backend/editor/OT/client_view.go
+++ b/backend/editor/OT/client_view.go
@@ -38,6 +38,7 @@ func (c *clientView) run(serverPipe pipe, terminatePipe alertLeaving) {
 		select {
 		case <-c.sendOp:
 			// push the operation down the websocket
+			// send an acknowledgement
 			break
 
 		case <-c.sendAcknowledgement:

--- a/backend/editor/OT/data/operationModel.go
+++ b/backend/editor/OT/data/operationModel.go
@@ -28,7 +28,8 @@ type (
 		EditType         EditType `json:"op"`
 		OperationPayload Payload  `json:"payload"`
 
-		IsNoOp bool
+		IsNoOp                bool
+		AcknowledgedServerOps int
 	}
 
 	// Payload is the actual data contained within the request

--- a/backend/editor/OT/worker.go
+++ b/backend/editor/OT/worker.go
@@ -2,10 +2,10 @@ package editor
 
 // worker is a single goroutine that listens for work to execute, it also optionally listens for a termination
 // signal the reason we have this is because we spin up a goroutine for each incoming keystroke from the client
-// so my suspicion is that the overhead of allocating a stack and then deallocating it on each keystroke
+// so my suspicion is that the overhead of allocating a stack and then de-allocating it on each keystroke
 // is rather costly (despite goroutines being rather lightweight)
 // TODO: in the future benchmark the actual impact of just spinning a goroutine on each keystroke
-// 		and remove this if it isnt actually as bad as suspected
+// 		and remove this if it isn't actually as bad as suspected
 // NOTE: each client is allocated one worker they can push work to :D
 
 type empty struct{}


### PR DESCRIPTION
PR just adds a record of all operations the server has ever applied, this is used to correctly transform incoming client operations against the requested base server OP as described in: https://lively-kernel.org/repository/webwerkstatt/projects/Collaboration/paper/Jupiter.pdf 

In the future to reduce memory usage we should dynamically remove OPs from this set that could no longer reasonably be the base for any incoming client operation (this could perhaps be achieve by associating a count with each index and decrementing until we hit 0?) but that's something to think about later.