### PR TITLE
Dependency Factory Refactor - Simplifying interface + Removing reflection

### DIFF
--- a/backend/database/repositories/dockerfilesystem.go
+++ b/backend/database/repositories/dockerfilesystem.go
@@ -28,7 +28,7 @@ type dockerPublishedFileSystemRepository struct {
 }
 
 // create new instances of the corresponding repository types
-func NewDockerPublishedFileSystemRepository() (*dockerPublishedFileSystemRepository, error) {
+func newDockerPublishedFileSystemRepository() (*dockerPublishedFileSystemRepository, error) {
 	inner, err := newDockerFilesystemRepositoryCore(publishedVolumePath)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func NewDockerPublishedFileSystemRepository() (*dockerPublishedFileSystemReposit
 }
 
 // create new instances of the corresponding repository types
-func NewDockerUnpublishedFileSystemRepository() (*dockerUnpublishedFileSystemRepository, error) {
+func newDockerUnpublishedFileSystemRepository() (*dockerUnpublishedFileSystemRepository, error) {
 	inner, err := newDockerFilesystemRepositoryCore(unpublishedVolumePath)
 	if err != nil {
 		return nil, err
@@ -68,25 +68,25 @@ func (c *dockerFileSystemRepositoryCore) AddToVolume(filename string) error {
 	// Check if source file is valid
 	src, err := os.Open(filename)
 	if err != nil {
-		return errors.New("Couldn't open source file")
+		return errors.New("couldn't open source file")
 	}
 	defer src.Close()
 	// Create/update destination file and check it is valid
 	filepath := filepath.Join(c.volumePath, filename)
 	moved, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0o755)
 	if err != nil {
-		return errors.New("Couldn't read/create the destination file")
+		return errors.New("couldn't read/create the destination file")
 	}
 	defer moved.Close()
 	// Copy source to destination
 	_, err = io.Copy(moved, src)
 	if err != nil {
-		return errors.New("File couldn't be copied to destination")
+		return errors.New("file couldn't be copied to destination")
 	}
 	// Delete source file
 	err = os.Remove(filename)
 	if err != nil {
-		return errors.New("Couldn't remove the source file")
+		return errors.New("couldn't remove the source file")
 	}
 	return nil
 }
@@ -98,13 +98,13 @@ func (c *dockerFileSystemRepositoryCore) CopyToVolume(src *os.File, filename str
 	filepath := filepath.Join(c.volumePath, filename)
 	copied, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0o755)
 	if err != nil {
-		return errors.New("Couldn't read/create the destination file")
+		return errors.New("couldn't read/create the destination file")
 	}
 	defer copied.Close()
 	// Copy source to destination
 	_, err = io.Copy(copied, src)
 	if err != nil {
-		return errors.New("File couldn't be copied to destination")
+		return errors.New("file couldn't be copied to destination")
 	}
 	return nil
 }
@@ -126,12 +126,12 @@ func (c *dockerFileSystemRepositoryCore) DeleteFromVolume(filename string) error
 	filepath := filepath.Join(c.volumePath, filename)
 	file, err := os.Open(filepath)
 	if err != nil {
-		return errors.New("File doesn't exist")
+		return errors.New("file doesn't exist")
 	}
 	file.Close()
 	os.Remove(filepath)
 	if err = os.Remove(filepath); err != nil {
-		return errors.New("Couldn't remove the source file")
+		return errors.New("couldn't remove the source file")
 	}
 	return nil
 }

--- a/backend/database/repositories/filesystem.go
+++ b/backend/database/repositories/filesystem.go
@@ -13,6 +13,9 @@ type filesystemRepository struct {
 	embeddedContext
 }
 
+// The ID for root, set this as the ID in a specified request
+var FilesystemRootID uuid.UUID = uuid.Nil
+
 // We really should use an ORM jesus this is ugly
 func (rep filesystemRepository) query(query string, input ...interface{}) (FilesystemEntry, error) {
 	entity := FilesystemEntry{}
@@ -48,7 +51,7 @@ func (rep filesystemRepository) query(query string, input ...interface{}) (Files
 
 // Returns: entry struct containing the entity that was just created
 func (rep filesystemRepository) CreateEntry(file FilesystemEntry) (FilesystemEntry, error) {
-	if file.ParentFileID == FILESYSTEM_ROOT_ID {
+	if file.ParentFileID == FilesystemRootID {
 		// determine root ID
 		root, err := rep.GetRoot()
 		if err != nil {
@@ -67,7 +70,7 @@ func (rep filesystemRepository) CreateEntry(file FilesystemEntry) (FilesystemEnt
 }
 
 func (rep filesystemRepository) GetEntryWithID(ID uuid.UUID) (FilesystemEntry, error) {
-	if ID == FILESYSTEM_ROOT_ID {
+	if ID == FilesystemRootID {
 		return rep.GetRoot()
 	}
 
@@ -77,7 +80,7 @@ func (rep filesystemRepository) GetEntryWithID(ID uuid.UUID) (FilesystemEntry, e
 
 func (rep filesystemRepository) GetRoot() (FilesystemEntry, error) {
 	// Root is currently set to ID 1
-	return rep.query("SELECT * FROM filesystem WHERE EntityID = $1", FILESYSTEM_ROOT_ID)
+	return rep.query("SELECT * FROM filesystem WHERE EntityID = $1", FilesystemRootID)
 }
 
 func (rep filesystemRepository) GetEntryWithParentID(ID uuid.UUID) (FilesystemEntry, error) {

--- a/backend/database/repositories/repository_interfaces.go
+++ b/backend/database/repositories/repository_interfaces.go
@@ -27,7 +27,7 @@ type FilesystemEntry struct {
 type (
 	// Repository interface that all valid filesystem repositories
 	// mocked/real should implement
-	IFilesystemRepository interface {
+	FilesystemRepository interface {
 		GetEntryWithID(ID uuid.UUID) (FilesystemEntry, error)
 		GetRoot() (FilesystemEntry, error)
 		GetEntryWithParentID(ID uuid.UUID) (FilesystemEntry, error)
@@ -44,7 +44,7 @@ type (
 	// Repository interface representing an underlying connection
 	// to a filesystem within a docker volume containing unpublished
 	// data
-	IUnpublishedVolumeRepository interface {
+	UnpublishedVolumeRepository interface {
 		AddToVolume(filename string) (err error)
 		CopyToVolume(src *os.File, filename string) (err error)
 		GetFromVolume(filename string) (fp *os.File, err error)
@@ -54,24 +54,24 @@ type (
 
 	// Repository interface representing a connection to
 	// the published data docker volume
-	IPublishedVolumeRepository interface {
-		IUnpublishedVolumeRepository
+	PublishedVolumeRepository interface {
+		UnpublishedVolumeRepository
 	}
 
 	// Note: only exists Email and Password
-	IPersonRepository interface {
+	PersonRepository interface {
 		PersonExists(Person) bool
 		GetPersonWithDetails(Person) Person
 	}
 
 	// repository interface for the groups table within the database
-	IGroupsRepository interface {
+	GroupsRepository interface {
 		// Only requires Groups.Name
 		GetGroupInfo(Groups) Groups
 	}
 
 	// repository interface for getting information from the frontend table
-	IFrontendsRepository interface {
+	FrontendsRepository interface {
 		GetFrontendFromURL(url string) int
 	}
 )

--- a/backend/database/repositories/tests/filesystem_test.go
+++ b/backend/database/repositories/tests/filesystem_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	repo        = repositories.GetRepository(repositories.FILESYSTEM).(repositories.IFilesystemRepository)
+	repo        = repositories.NewFilesystemRepo()
 	testContext = repo.GetContext().(*contexts.TestingContext)
 )
 
@@ -43,7 +43,7 @@ func TestRootInsert(t *testing.T) {
 		root, _ := repo.GetRoot()
 
 		newDir, _ := repo.CreateEntry(repositories.FilesystemEntry{
-			LogicalName: "test_directory", ParentFileID: repositories.FILESYSTEM_ROOT_ID,
+			LogicalName: "test_directory", ParentFileID: repositories.FilesystemRootID,
 			OwnerUserId: repositories.GROUPS_ADMIN, IsDocument: false,
 		})
 
@@ -82,7 +82,7 @@ func TestDocumentInfoRetrieval(t *testing.T) {
 	testContext.RunTest(func() {
 		// ==== Setup ====
 		newDoc, err := repo.CreateEntry(repositories.FilesystemEntry{
-			LogicalName: "test_doc", ParentFileID: repositories.FILESYSTEM_ROOT_ID,
+			LogicalName: "test_doc", ParentFileID: repositories.FilesystemRootID,
 			OwnerUserId: repositories.GROUPS_ADMIN, IsDocument: true,
 		})
 		// ==== Assertions ====
@@ -108,7 +108,7 @@ func TestEntityDeletion(t *testing.T) {
 
 		newDir, _ := repo.CreateEntry(repositories.FilesystemEntry{
 			LogicalName: "cool_dir", OwnerUserId: repositories.GROUPS_ADMIN,
-			ParentFileID: repositories.FILESYSTEM_ROOT_ID, IsDocument: false,
+			ParentFileID: repositories.FilesystemRootID, IsDocument: false,
 		})
 
 		newDoc, _ := repo.CreateEntry(repositories.FilesystemEntry{
@@ -131,7 +131,7 @@ func TestEntityDeletion(t *testing.T) {
 		// ======= Secondary setup ==========
 		anotherDirectory, _ := repo.CreateEntry(repositories.FilesystemEntry{
 			LogicalName: "cheese", OwnerUserId: repositories.GROUPS_ADMIN,
-			ParentFileID: repositories.FILESYSTEM_ROOT_ID, IsDocument: false,
+			ParentFileID: repositories.FilesystemRootID, IsDocument: false,
 		})
 
 		nestedDirectory, _ := repo.CreateEntry(repositories.FilesystemEntry{
@@ -169,7 +169,7 @@ func TestEntityRename(t *testing.T) {
 
 	testContext.RunTest(func() {
 		// ===== Test setup =====
-		newDir, _ := repo.CreateEntry(getEntity("cool_dir", repositories.GROUPS_ADMIN, repositories.FILESYSTEM_ROOT_ID, false))
+		newDir, _ := repo.CreateEntry(getEntity("cool_dir", repositories.GROUPS_ADMIN, repositories.FilesystemRootID, false))
 		newDoc, _ := repo.CreateEntry(getEntity("cool_doc", repositories.GROUPS_ADMIN, newDir.EntityID, false))
 		newDoc1, _ := repo.CreateEntry(getEntity("cool_doc1", repositories.GROUPS_ADMIN, newDir.EntityID, false))
 		newDoc2, _ := repo.CreateEntry(getEntity("cool_doc2", repositories.GROUPS_ADMIN, newDir.EntityID, false))
@@ -197,11 +197,11 @@ func TestEntityChildren(t *testing.T) {
 
 	testContext.RunTest(func() {
 		// Test setup
-		dir1, _ := repo.CreateEntry(getEntity("d1", repositories.GROUPS_ADMIN, false, repositories.FILESYSTEM_ROOT_ID))
-		dir2, _ := repo.CreateEntry(getEntity("d2", repositories.GROUPS_ADMIN, false, repositories.FILESYSTEM_ROOT_ID))
-		dir3, _ := repo.CreateEntry(getEntity("d3", repositories.GROUPS_ADMIN, false, repositories.FILESYSTEM_ROOT_ID))
-		dir4, _ := repo.CreateEntry(getEntity("d4", repositories.GROUPS_ADMIN, false, repositories.FILESYSTEM_ROOT_ID))
-		emptyDir, _ := repo.CreateEntry(getEntity("de", repositories.GROUPS_ADMIN, false, repositories.FILESYSTEM_ROOT_ID))
+		dir1, _ := repo.CreateEntry(getEntity("d1", repositories.GROUPS_ADMIN, false, repositories.FilesystemRootID))
+		dir2, _ := repo.CreateEntry(getEntity("d2", repositories.GROUPS_ADMIN, false, repositories.FilesystemRootID))
+		dir3, _ := repo.CreateEntry(getEntity("d3", repositories.GROUPS_ADMIN, false, repositories.FilesystemRootID))
+		dir4, _ := repo.CreateEntry(getEntity("d4", repositories.GROUPS_ADMIN, false, repositories.FilesystemRootID))
+		emptyDir, _ := repo.CreateEntry(getEntity("de", repositories.GROUPS_ADMIN, false, repositories.FilesystemRootID))
 
 		for x := 1; x < 10; x++ {
 			if x%3 == 0 {
@@ -243,7 +243,7 @@ func TestGetIDWithPath(t *testing.T) {
 
 	testContext.RunTest(func() {
 		// Test setup
-		dir1, _ := repo.CreateEntry(getEntity("d1", repositories.GROUPS_ADMIN, false, repositories.FILESYSTEM_ROOT_ID))
+		dir1, _ := repo.CreateEntry(getEntity("d1", repositories.GROUPS_ADMIN, false, repositories.FilesystemRootID))
 		currentDir := dir1
 		for x := 1; x < 3; x++ {
 			newDir, _ := repo.CreateEntry(getEntity("cool_doc"+fmt.Sprint(x), repositories.GROUPS_ADMIN, false, currentDir.EntityID))

--- a/backend/editor/diffSync/document/manager.go
+++ b/backend/editor/diffSync/document/manager.go
@@ -18,9 +18,11 @@ type Manager struct {
 	readingDocuments *sync.RWMutex
 }
 
-var managerInstance *Manager
-var lock = &sync.Mutex{}
-var repo = repositories.GetRepository(repositories.FILESYSTEM).(repositories.IFilesystemRepository)
+var (
+	managerInstance *Manager
+	lock            = &sync.Mutex{}
+	repo            = repositories.NewFilesystemRepo()
+)
 
 // implementation of the singleton pattern :)
 func GetManagerInstance() *Manager {

--- a/backend/editor/pessimistic/main.go
+++ b/backend/editor/pessimistic/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // This is the main loop that the editor client will run
-func EditorClientLoop(requestedDocument uuid.UUID, fs repositories.IUnpublishedVolumeRepository, ws *websocket.Conn) error {
+func EditorClientLoop(requestedDocument uuid.UUID, fs repositories.UnpublishedVolumeRepository, ws *websocket.Conn) error {
 	manager := getGlobalManagerInstance()
 	err := manager.startDocumentServer(requestedDocument)
 	if err != nil {

--- a/backend/endpoints/auth_endpoints.go
+++ b/backend/endpoints/auth_endpoints.go
@@ -20,7 +20,7 @@ import (
 
 // LoginHandler is a HTTP login handler
 func LoginHandler(form User, w http.ResponseWriter, r *http.Request, df DependencyFactory) handlerResponse[empty] {
-	if !form.IsValidEmail() || !form.UserExists() {
+	if !form.IsValidEmail() || !form.UserExists(df.GetPersonsRepo()) {
 		return handlerResponse[empty]{
 			Status: http.StatusUnauthorized,
 		}

--- a/backend/endpoints/dependency_factory.go
+++ b/backend/endpoints/dependency_factory.go
@@ -3,56 +3,23 @@ package endpoints
 //go:generate mockgen -source=dependency_factory.go -destination=mocks/dependency_factory_mock.go -package=mocks
 
 import (
-	"reflect"
-
-	"cms.csesoc.unsw.edu.au/database/repositories"
+	repos "cms.csesoc.unsw.edu.au/database/repositories"
 	"cms.csesoc.unsw.edu.au/internal/logger"
 )
-
-// Dependency Types that the factory supports
-type Dependency int
-
-const (
-	FileSystemRepository Dependency = iota
-	GroupsRepository
-	PersonRepository
-	FrontEndRepository
-
-	UnpublishedVolumeRepository
-	PublishedVolumeRepository
-
-	Log
-)
-
-// baseDependencyMappings contains all the mappings that are non-specific to the execution of a handler and are instead global
-// an example of a non-baseDependencyMapping is a logger dependency (as each function maintains its own log)
-var baseDependencyMappings = map[Dependency]func() interface{}{
-	FileSystemRepository: func() interface{} { return repositories.GetRepository(repositories.FILESYSTEM) },
-	GroupsRepository:     func() interface{} { return repositories.GetRepository(repositories.GROUPS) },
-	FrontEndRepository:   func() interface{} { return repositories.GetRepository(repositories.FRONTENDS) },
-
-	UnpublishedVolumeRepository: func() interface{} { return repositories.GetRepository(repositories.DOCKER_UNPUBLISHED_FILESYSTEM) },
-	PublishedVolumeRepository:   func() interface{} { return repositories.GetRepository(repositories.DOCKER_PUBLISHED_FILESYSTEM) },
-}
-
-// baseTypeDependencyMappings maps reflect.Types to the underlying dependency ID (mostly just used by the getDependency helper)
-var baseTypeDependencyMappings = map[reflect.Type]Dependency{
-	reflect.TypeOf((*repositories.IFilesystemRepository)(nil)): FileSystemRepository,
-	reflect.TypeOf((*repositories.IGroupsRepository)(nil)):     GroupsRepository,
-	reflect.TypeOf((*repositories.IPersonRepository)(nil)):     PersonRepository,
-	reflect.TypeOf((*repositories.IFrontendsRepository)(nil)):  FrontEndRepository,
-
-	reflect.TypeOf((*repositories.IPublishedVolumeRepository)(nil)):   PublishedVolumeRepository,
-	reflect.TypeOf((*repositories.IUnpublishedVolumeRepository)(nil)): UnpublishedVolumeRepository,
-}
 
 type (
 	// DependencyFactory is an interface type that handlers can use to retrieve
 	// and fetch specific dependencies
 	DependencyFactory interface {
-		GetDependency(depType Dependency) interface{}
-		// GetDepFromType converts a reflect.Type into a dependency ID
-		GetDepFromType(reflect.Type) Dependency
+		GetFilesystemRepo() repos.FilesystemRepository
+		GetGroupsRepo() repos.GroupsRepository
+		GetFrontendsRepo() repos.FrontendsRepository
+		GetPersonsRepo() repos.PersonRepository
+
+		GetUnpublishedVolumeRepo() repos.UnpublishedVolumeRepository
+		GetPublishedVolumeRepo() repos.PublishedVolumeRepository
+
+		GetLogger() *logger.Log
 	}
 
 	// DependencyProvider is a simple implementation of the dependency factory that supports the injection of "dynamic" dependencies
@@ -62,26 +29,36 @@ type (
 	}
 )
 
-// GetDependency constructs a dependency given the required dependency type
-func (dp DependencyProvider) GetDependency(depType Dependency) interface{} {
-	// setup a dependency mapping by first taking the base dependencies and adding handler specific ones
-	dependencies := baseDependencyMappings
-	dependencies[Log] = func() interface{} { return dp.Log }
-	dependencies[PersonRepository] = func() interface{} { return repositories.PersonRepository(dp.FrontEndID) }
-
-	return dependencies[depType]()
+// GetFilesystemRepo is the constructor for FS repos
+func (dp DependencyProvider) GetFilesystemRepo() repos.FilesystemRepository {
+	return repos.NewFilesystemRepo()
 }
 
-func (dp DependencyProvider) GetDepFromType(t reflect.Type) Dependency {
-	depTypeMappings := baseTypeDependencyMappings
-	depTypeMappings[reflect.TypeOf((**logger.Log)(nil))] = Log
-
-	return depTypeMappings[t]
+// GetGroupsRepo instantiates a new groups repository
+func (dp DependencyProvider) GetGroupsRepo() repos.GroupsRepository {
+	return repos.NewGroupsRepo()
 }
 
-// getDependency is a small little generic wrapper around the dependency factor to make fetching dependencies cleaner
-func getDependency[T any](factory DependencyFactory) T {
-	typeMapping := reflect.TypeOf((*T)(nil))
+// GetFrontendsRepo instantiates a new frontend repository
+func (dp DependencyProvider) GetFrontendsRepo() repos.FrontendsRepository {
+	return repos.NewFrontendsRepo()
+}
 
-	return factory.GetDependency(factory.GetDepFromType(typeMapping)).(T)
+// GetPersonsRepo instantiates a new person repository
+func (dp DependencyProvider) GetPersonsRepo() repos.PersonRepository {
+	return repos.NewPersonRepo(dp.FrontEndID)
+}
+
+// GetUnpublishedVolumeRepo instantiates a new instance of the unpublished volume repository
+func (dp DependencyProvider) GetUnpublishedVolumeRepo() repos.UnpublishedVolumeRepository {
+	return repos.NewUnpublishedRepo()
+}
+
+// PublishedVolumeRepo instantiates an instance of the published volume repository
+func (dp DependencyProvider) GetPublishedVolumeRepo() repos.PublishedVolumeRepository {
+	return repos.NewPublishedRepo()
+}
+
+func (dp DependencyProvider) GetLogger() *logger.Log {
+	return dp.Log
 }

--- a/backend/endpoints/editor_endpoints.go
+++ b/backend/endpoints/editor_endpoints.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"cms.csesoc.unsw.edu.au/database/repositories"
 	editor "cms.csesoc.unsw.edu.au/editor/pessimistic"
 	. "cms.csesoc.unsw.edu.au/endpoints/models"
-	"cms.csesoc.unsw.edu.au/internal/logger"
 	"github.com/gorilla/websocket"
 )
 
@@ -23,8 +21,8 @@ var Upgrader = websocket.Upgrader{
 // EditHandler is the HTTP handler responsible for dealing with incoming requests to edit a document
 // for the most part this is passed over to the editor package
 func EditHandler(form ValidEditRequest, w http.ResponseWriter, r *http.Request, df DependencyFactory) handlerResponse[empty] {
-	unpublishedVol := getDependency[repositories.IUnpublishedVolumeRepository](df)
-	log := getDependency[*logger.Log](df)
+	unpublishedVol := df.GetUnpublishedVolumeRepo()
+	log := df.GetLogger()
 
 	ws, err := Upgrader.Upgrade(w, r, nil)
 	if err != nil {

--- a/backend/endpoints/filesystem_endpoints.go
+++ b/backend/endpoints/filesystem_endpoints.go
@@ -34,7 +34,7 @@ func GetEntityInfo(form ValidInfoRequest, df DependencyFactory) handlerResponse[
 func CreateNewEntity(form ValidEntityCreationRequest, df DependencyFactory) handlerResponse[NewEntityResponse] {
 	log := df.GetLogger()
 	fsRepo := df.GetFilesystemRepo()
-	pubRepo := df.GetPublishedVolumeRepo()
+	pubRepo := df.GetUnpublishedVolumeRepo()
 
 	entityToCreate := CreationReqToFsEntry(form)
 	newEntity, err := fsRepo.CreateEntry(entityToCreate)

--- a/backend/endpoints/filesystem_endpoints.go
+++ b/backend/endpoints/filesystem_endpoints.go
@@ -4,16 +4,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"cms.csesoc.unsw.edu.au/database/repositories"
 	. "cms.csesoc.unsw.edu.au/endpoints/models"
-	"cms.csesoc.unsw.edu.au/internal/logger"
 	"github.com/google/uuid"
 )
 
 // Defines endpoints consumable via the API
 func GetEntityInfo(form ValidInfoRequest, df DependencyFactory) handlerResponse[EntityInfoResponse] {
-	log := getDependency[*logger.Log](df)
-	fsRepo := getDependency[repositories.IFilesystemRepository](df)
+	log := df.GetLogger()
+	fsRepo := df.GetFilesystemRepo()
 
 	// Query the repository for an existing entity with the given ID
 	entity, err := fsRepo.GetEntryWithID(form.EntityID)
@@ -34,9 +32,9 @@ func GetEntityInfo(form ValidInfoRequest, df DependencyFactory) handlerResponse[
 
 // CreateNewEntity is the public handler for constructing and creating new entities
 func CreateNewEntity(form ValidEntityCreationRequest, df DependencyFactory) handlerResponse[NewEntityResponse] {
-	fsRepo := getDependency[repositories.IFilesystemRepository](df)
-	pubRepo := getDependency[repositories.IUnpublishedVolumeRepository](df)
-	log := getDependency[*logger.Log](df)
+	log := df.GetLogger()
+	fsRepo := df.GetFilesystemRepo()
+	pubRepo := df.GetPublishedVolumeRepo()
 
 	entityToCreate := CreationReqToFsEntry(form)
 	newEntity, err := fsRepo.CreateEntry(entityToCreate)
@@ -56,8 +54,8 @@ func CreateNewEntity(form ValidEntityCreationRequest, df DependencyFactory) hand
 
 // Handler for deleting filesystem entities
 func DeleteFilesystemEntity(form ValidInfoRequest, df DependencyFactory) handlerResponse[empty] {
-	fsRepo := getDependency[repositories.IFilesystemRepository](df)
-	log := getDependency[*logger.Log](df)
+	log := df.GetLogger()
+	fsRepo := df.GetFilesystemRepo()
 
 	err := fsRepo.DeleteEntryWithID(form.EntityID)
 	if err != nil {
@@ -74,8 +72,8 @@ func DeleteFilesystemEntity(form ValidInfoRequest, df DependencyFactory) handler
 
 // Handler for retrieving children
 func GetChildren(form ValidInfoRequest, df DependencyFactory) handlerResponse[ChildrenRequestResponse] {
-	fsRepo := getDependency[repositories.IFilesystemRepository](df)
-	log := getDependency[*logger.Log](df)
+	log := df.GetLogger()
+	fsRepo := df.GetFilesystemRepo()
 
 	fileInfo, err := fsRepo.GetEntryWithID(form.EntityID)
 	if err != nil {
@@ -94,8 +92,8 @@ func GetChildren(form ValidInfoRequest, df DependencyFactory) handlerResponse[Ch
 }
 
 func GetIDWithPath(form ValidPathRequest, df DependencyFactory) handlerResponse[uuid.UUID] {
-	repository := getDependency[repositories.IFilesystemRepository](df)
-	log := getDependency[*logger.Log](df)
+	log := df.GetLogger()
+	repository := df.GetFilesystemRepo()
 
 	entityID, err := repository.GetIDWithPath(form.Path)
 	if err != nil {
@@ -112,7 +110,7 @@ func GetIDWithPath(form ValidPathRequest, df DependencyFactory) handlerResponse[
 
 // Handler for renaming filesystem entities
 func RenameFilesystemEntity(form ValidRenameRequest, df DependencyFactory) handlerResponse[empty] {
-	repository := getDependency[repositories.IFilesystemRepository](df)
+	repository := df.GetFilesystemRepo()
 	err := repository.RenameEntity(form.EntityID, form.NewName)
 	if err != nil {
 		return handlerResponse[empty]{Status: http.StatusNotAcceptable}

--- a/backend/endpoints/main.go
+++ b/backend/endpoints/main.go
@@ -117,7 +117,7 @@ func (fn rawHandler[T, V]) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // getFrontendID gets the frontend id for an incoming http request
 func getFrontendId(r *http.Request) int {
-	frontendRepo := repositories.GetRepository(repositories.FRONTENDS).(repositories.IFrontendsRepository)
+	frontendRepo := repositories.NewFrontendsRepo()
 	return frontendRepo.GetFrontendFromURL(r.URL.Host)
 }
 

--- a/backend/endpoints/mocks/dependency_factory_mock.go
+++ b/backend/endpoints/mocks/dependency_factory_mock.go
@@ -7,7 +7,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	endpoints "cms.csesoc.unsw.edu.au/endpoints"
+	repositories "cms.csesoc.unsw.edu.au/database/repositories"
+	logger "cms.csesoc.unsw.edu.au/internal/logger"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -34,30 +35,100 @@ func (m *MockDependencyFactory) EXPECT() *MockDependencyFactoryMockRecorder {
 	return m.recorder
 }
 
-// GetDepFromType mocks base method.
-func (m *MockDependencyFactory) GetDepFromType(arg0 reflect.Type) endpoints.Dependency {
+// GetFilesystemRepo mocks base method.
+func (m *MockDependencyFactory) GetFilesystemRepo() repositories.FilesystemRepository {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDepFromType", arg0)
-	ret0, _ := ret[0].(endpoints.Dependency)
+	ret := m.ctrl.Call(m, "GetFilesystemRepo")
+	ret0, _ := ret[0].(repositories.FilesystemRepository)
 	return ret0
 }
 
-// GetDepFromType indicates an expected call of GetDepFromType.
-func (mr *MockDependencyFactoryMockRecorder) GetDepFromType(arg0 interface{}) *gomock.Call {
+// GetFilesystemRepo indicates an expected call of GetFilesystemRepo.
+func (mr *MockDependencyFactoryMockRecorder) GetFilesystemRepo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDepFromType", reflect.TypeOf((*MockDependencyFactory)(nil).GetDepFromType), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilesystemRepo", reflect.TypeOf((*MockDependencyFactory)(nil).GetFilesystemRepo))
 }
 
-// GetDependency mocks base method.
-func (m *MockDependencyFactory) GetDependency(depType endpoints.Dependency) interface{} {
+// GetFrontendsRepo mocks base method.
+func (m *MockDependencyFactory) GetFrontendsRepo() repositories.FrontendsRepository {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDependency", depType)
-	ret0, _ := ret[0].(interface{})
+	ret := m.ctrl.Call(m, "GetFrontendsRepo")
+	ret0, _ := ret[0].(repositories.FrontendsRepository)
 	return ret0
 }
 
-// GetDependency indicates an expected call of GetDependency.
-func (mr *MockDependencyFactoryMockRecorder) GetDependency(depType interface{}) *gomock.Call {
+// GetFrontendsRepo indicates an expected call of GetFrontendsRepo.
+func (mr *MockDependencyFactoryMockRecorder) GetFrontendsRepo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDependency", reflect.TypeOf((*MockDependencyFactory)(nil).GetDependency), depType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFrontendsRepo", reflect.TypeOf((*MockDependencyFactory)(nil).GetFrontendsRepo))
+}
+
+// GetGroupsRepo mocks base method.
+func (m *MockDependencyFactory) GetGroupsRepo() repositories.GroupsRepository {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGroupsRepo")
+	ret0, _ := ret[0].(repositories.GroupsRepository)
+	return ret0
+}
+
+// GetGroupsRepo indicates an expected call of GetGroupsRepo.
+func (mr *MockDependencyFactoryMockRecorder) GetGroupsRepo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupsRepo", reflect.TypeOf((*MockDependencyFactory)(nil).GetGroupsRepo))
+}
+
+// GetLogger mocks base method.
+func (m *MockDependencyFactory) GetLogger() *logger.Log {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogger")
+	ret0, _ := ret[0].(*logger.Log)
+	return ret0
+}
+
+// GetLogger indicates an expected call of GetLogger.
+func (mr *MockDependencyFactoryMockRecorder) GetLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockDependencyFactory)(nil).GetLogger))
+}
+
+// GetPersonsRepo mocks base method.
+func (m *MockDependencyFactory) GetPersonsRepo() repositories.PersonRepository {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPersonsRepo")
+	ret0, _ := ret[0].(repositories.PersonRepository)
+	return ret0
+}
+
+// GetPersonsRepo indicates an expected call of GetPersonsRepo.
+func (mr *MockDependencyFactoryMockRecorder) GetPersonsRepo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPersonsRepo", reflect.TypeOf((*MockDependencyFactory)(nil).GetPersonsRepo))
+}
+
+// GetPublishedVolumeRepo mocks base method.
+func (m *MockDependencyFactory) GetPublishedVolumeRepo() repositories.PublishedVolumeRepository {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublishedVolumeRepo")
+	ret0, _ := ret[0].(repositories.PublishedVolumeRepository)
+	return ret0
+}
+
+// GetPublishedVolumeRepo indicates an expected call of GetPublishedVolumeRepo.
+func (mr *MockDependencyFactoryMockRecorder) GetPublishedVolumeRepo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishedVolumeRepo", reflect.TypeOf((*MockDependencyFactory)(nil).GetPublishedVolumeRepo))
+}
+
+// GetUnpublishedVolumeRepo mocks base method.
+func (m *MockDependencyFactory) GetUnpublishedVolumeRepo() repositories.UnpublishedVolumeRepository {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnpublishedVolumeRepo")
+	ret0, _ := ret[0].(repositories.UnpublishedVolumeRepository)
+	return ret0
+}
+
+// GetUnpublishedVolumeRepo indicates an expected call of GetUnpublishedVolumeRepo.
+func (mr *MockDependencyFactoryMockRecorder) GetUnpublishedVolumeRepo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnpublishedVolumeRepo", reflect.TypeOf((*MockDependencyFactory)(nil).GetUnpublishedVolumeRepo))
 }

--- a/backend/endpoints/models/filesystem_models.go
+++ b/backend/endpoints/models/filesystem_models.go
@@ -56,7 +56,7 @@ type (
 
 // FsEntryToEntityInfo just converts an instance of an FS entry to an instance of an entityInfo object
 // entityInfo objects are what is actually displayed to the end user
-func FsEntryToEntityInfo(entity repositories.FilesystemEntry, fsRepo repositories.IFilesystemRepository, expandChildren bool) EntityInfoResponse {
+func FsEntryToEntityInfo(entity repositories.FilesystemEntry, fsRepo repositories.FilesystemRepository, expandChildren bool) EntityInfoResponse {
 	children := []EntityInfoResponse{}
 	if expandChildren {
 		for _, childId := range entity.ChildrenIDs {

--- a/backend/endpoints/models/user_models.go
+++ b/backend/endpoints/models/user_models.go
@@ -31,11 +31,10 @@ func (u *User) IsValidEmail() bool {
 }
 
 // UserExists just checks if a user has a valid password
-func (u *User) UserExists() bool {
+func (u *User) UserExists(personRepo repositories.PersonRepository) bool {
 	hashedPassword := u.hashPassword()
-	repository := repositories.GetRepository(repositories.PERSON).(repositories.IPersonRepository)
 
-	return repository.PersonExists(repositories.Person{
+	return personRepo.PersonExists(repositories.Person{
 		Email:    u.Email,
 		Password: hashedPassword,
 	})

--- a/backend/endpoints/volume_endpoints.go
+++ b/backend/endpoints/volume_endpoints.go
@@ -8,14 +8,13 @@ import (
 
 	"cms.csesoc.unsw.edu.au/database/repositories"
 	. "cms.csesoc.unsw.edu.au/endpoints/models"
-	"cms.csesoc.unsw.edu.au/internal/logger"
 )
 
 // UploadImage takes an image from a request and uploads it to the published docker volume
 func UploadImage(form ValidImageUploadRequest, df DependencyFactory) handlerResponse[NewEntityResponse] {
-	dockerRepository := getDependency[repositories.IUnpublishedVolumeRepository](df)
-	repository := getDependency[repositories.IFilesystemRepository](df)
-	log := getDependency[*logger.Log](df)
+	dockerRepository := df.GetUnpublishedVolumeRepo()
+	repository := df.GetFilesystemRepo()
+	log := df.GetLogger()
 
 	// Remember to close all multipart forms
 	defer form.Image.Close()
@@ -56,8 +55,8 @@ func UploadImage(form ValidImageUploadRequest, df DependencyFactory) handlerResp
 
 // PublishDocument takes in DocumentID and transfers the document from unpublished to published volume if it exists
 func PublishDocument(form ValidPublishDocumentRequest, df DependencyFactory) handlerResponse[empty] {
-	unpublishedVol := getDependency[repositories.IUnpublishedVolumeRepository](df)
-	publishedVol := getDependency[repositories.IPublishedVolumeRepository](df)
+	unpublishedVol := df.GetUnpublishedVolumeRepo()
+	publishedVol := df.GetPublishedVolumeRepo()
 
 	// fetch the target file form the unpublished volume
 	filename := form.DocumentID.String()
@@ -82,8 +81,8 @@ const emptyFile string = "{}"
 
 // GetPublishedDocument retrieves the contents of a published document from the published docker volume
 func GetPublishedDocument(form ValidGetPublishedDocumentRequest, df DependencyFactory) handlerResponse[DocumentRetrievalResponse] {
-	publishedVol := getDependency[repositories.IPublishedVolumeRepository](df)
-	log := getDependency[*logger.Log](df)
+	publishedVol := df.GetPublishedVolumeRepo()
+	log := df.GetLogger()
 
 	// Get file from published volume
 	file, err := publishedVol.GetFromVolume(form.DocumentID.String())


### PR DESCRIPTION
This PR just simplifies the dependency factory + the repository constructors, neither of them now rely on magic constants for initiating repos/dependencies allowing for easier interface mocking and better type safety